### PR TITLE
Update sdk-intro-veretxai.ipynb to fix calls to send(...)

### DIFF
--- a/part_1_intro/chapter_01/sdk-intro-veretxai.ipynb
+++ b/part_1_intro/chapter_01/sdk-intro-veretxai.ipynb
@@ -81,7 +81,7 @@
     "async with client.aio.live.connect(model=model_id, config=config) as session:\n",
     "    message = \"Hello? Gemini, are you there?\"\n",
     "    print(\"> \", message, \"\\n\")\n",
-    "    await session.send(message, end_of_turn=True)\n",
+    "    await session.send(input=message, end_of_turn=True)\n",
     "\n",
     "    async for response in session.receive():\n",
     "        print(response.text)"
@@ -165,7 +165,7 @@
     "  with wave_file(file_name) as wav:\n",
     "    message = \"Hello? Gemini are you there?\"\n",
     "    print(\"> \", message, \"\\n\")\n",
-    "    await session.send(message, end_of_turn=True)\n",
+    "    await session.send(input=message, end_of_turn=True)\n",
     "\n",
     "    first = True\n",
     "    async for response in session.receive():\n",


### PR DESCRIPTION
Following the doc:
https://googleapis.github.io/python-genai/genai.html#module-genai.live

This fixes the type error when executing for example in Google Colab:

"""python
client = genai.Client(api_key=API_KEY)
config = {}
async with client.aio.live.connect(model='gemini-1.0-pro-002', config=config) as session: await session.send(input='Hello world!', end_of_turn=True) async for message in session: print(message)
"""