### PR TITLE
Fix LiveConnectConfig validation error

### DIFF
--- a/part_1_intro/chapter_01/sdk-intro.ipynb
+++ b/part_1_intro/chapter_01/sdk-intro.ipynb
@@ -23,11 +23,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from google import genai\n",
+    "from google.genai.types import LiveConnectConfig\n",
+    "\n",
     "client = genai.Client(vertexai=False, http_options= {'api_version': 'v1alpha'}, api_key='<YOUR_API_KEY>')"
    ]
   },
@@ -55,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -71,8 +73,7 @@
     }
    ],
    "source": [
-    "config={\n",
-    "    \"generation_config\": {\"response_modalities\": [\"TEXT\"]}}\n",
+    "config=LiveConnectConfig(response_modalities=[\"TEXT\"])\n",
     "\n",
     "async with client.aio.live.connect(model=MODEL, config=config) as session:\n",
     "  message = \"Hello? Gemini are you there?\"\n",
@@ -122,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -156,8 +157,7 @@
    "source": [
     "from IPython.display import display, Audio\n",
     "\n",
-    "config={\n",
-    "    \"generation_config\": {\"response_modalities\": [\"AUDIO\"]}}\n",
+    "config=LiveConnectConfig(response_modalities=[\"AUDIO\"])\n",
     "\n",
     "async with client.aio.live.connect(model=MODEL, config=config) as session:\n",
     "  file_name = 'audio.wav'\n",

--- a/part_1_intro/chapter_01/sdk-intro.ipynb
+++ b/part_1_intro/chapter_01/sdk-intro.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
I encountered a validation error during testing with Jupyter Notebook.
The public demo[1] indicates that perhaps we should use LiveConnectConfig to set response modalities.

```
ValidationError: 1 validation error for LiveConnectConfig
generation_config.response_modalities
  Extra inputs are not permitted [type=extra_forbidden, input_value=['TEXT'], input_type=list]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
```

```
ValidationError: 1 validation error for LiveConnectConfig
generation_config.response_modalities
  Extra inputs are not permitted [type=extra_forbidden, input_value=['AUDIO'], input_type=list]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
```

[1] https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb